### PR TITLE
Docker build added

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:17-bullseye-slim AS BUILDER
+WORKDIR /usr/src/app
+RUN apt update && apt install --no-install-recommends --no-install-suggests -y git ca-certificates python3 python3-pip make build-essential
+RUN git clone https://github.com/tejado/telegram-nearby-map .
+RUN npm install
+
+FROM node:17-bullseye-slim as FINAL
+WORKDIR /usr/src/app
+COPY --from=BUILDER /usr/src/app ./
+COPY config.js ./
+EXPOSE 3000
+CMD npm start

--- a/docker/run.md
+++ b/docker/run.md
@@ -1,0 +1,12 @@
+# How to use the docker version
+
+## build it
+docker build -t telegram-map .
+
+## run it 
+docker run --rm -ti -e PORT=3000 -e HOST=0.0.0.0 -e TELEGRAM_API_ID=<your-api-id> -e TELEGRAM_API_HASH=<your-api-hash> -p 3000:3000 telegram-map
+
+
+## Tips
+
+Run it this way is safer as it will ask for your phone number and confirmation code every time the app starts.


### PR DESCRIPTION
Greetings,

I created a simple docker version, which was double staged for anyone whom using their own registry or want to move docker image after build. API_ID and API_HASH loaded from env so that it can be called easily. There is a room for improvement, however is does the job. Of course because of the native lib dependencies (which could be integrated later to make it cross-platform) it's only works on x86_64